### PR TITLE
Prepare for Docker build and run.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git/
+.gitignore
+local.properties

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM sirlatrom/android:19
+
+ENV HOME /root
+ENV LD_LIBRARY_PATH ${ANDROID_HOME}/tools/lib
+
+RUN echo no | android create avd --force -n test -t android-19
+
+WORKDIR /workspace
+ADD ./gradlew /workspace/gradlew
+ADD ./gradle /workspace/gradle
+RUN ./gradlew
+
+ADD . /workspace
+
+RUN /workspace/gradlew assembleDebugTest
+
+ADD start-emulator    /usr/local/bin/
+ADD wait-for-emulator /usr/local/bin/
+
+CMD start-emulator "/workspace/gradlew connectedAndroidTest"

--- a/start-emulator
+++ b/start-emulator
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+if [ $# -gt 0 ]; then
+  CMD=$1
+  PORT=5554
+  echo "Starting emulator[$PORT]..."
+  emulator -avd test -no-skin -no-audio -no-window -port $PORT &
+  wait-for-emulator
+  $CMD
+else
+  echo "No command is specified"
+fi
+

--- a/wait-for-emulator
+++ b/wait-for-emulator
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+echo "Waiting for emulator to start..."
+
+bootanim=""
+failcounter=0
+until [[ "$bootanim" =~ "stopped" ]]; do
+   bootanim=`adb -e shell getprop init.svc.bootanim 2>&1`
+   if [[ "$bootanim" =~ "not found" ]]; then
+      let "failcounter += 1"
+      if [[ $failcounter -gt 600 ]]; then
+        echo "  Failed to start emulator"
+        exit 1
+      fi
+   fi
+   sleep 1
+done
+


### PR DESCRIPTION
Enables running the `connectedAndroidTest` task inside a <a href='http://www.docker.com'>Docker</a> container to check installability of the app. This works in Jenkins too, e.g. <a href='http://www.griffenfeld.dk:8080/job/LockscreenDisablerTest/27/console'>this build</a>.

To use, install docker and run the following:

```
docker build -t android-lockscreen-disabler .
docker run --rm android-lockscreen-disabler
```

When you update your code, you can run the above again.

The benefits of running the emulator in Docker are reproducibility (the emulator will be clean each time) and portability.
