### PR TITLE
Fix isSecure for settings app to not check the timer - as the timer will...

### DIFF
--- a/app/src/main/java/com/lr/keyguarddisabler/Lockscreen.java
+++ b/app/src/main/java/com/lr/keyguarddisabler/Lockscreen.java
@@ -127,15 +127,11 @@ public class Lockscreen implements IXposedHookLoadPackage, IXposedHookZygoteInit
 
                 @Override
                 protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
-                    boolean setResult = false;
+                    // This is for settings - so no need to hide based on a timer since by definition we're unlocked if this triggers.
                     if (lockScreenType.equals(LOCK_SCREEN_TYPE_SLIDE)) {
-                        if (hideLockBasedOnTimer()) {
-                            param.setResult(false);
-                            setResult = true;
-                        }
+                        param.setResult(false);
                     }
-                    if (LOG)
-                        XposedBridge.log("Keyguard Disabler: isSecure called by: " + lpparam.packageName + ".  Result overriden to false? " + setResult);
+                    if (LOG) XposedBridge.log("Keyguard Disabler: isSecure called by: " + lpparam.packageName);
                 }
             });
         }


### PR DESCRIPTION
... always show as first boot

for the settings app since the variables obviously aren't shared between packages.

This fixes bug #16 
