### PR TITLE
Added BroadcastReceiver to change preferences by intents

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,7 +34,7 @@
             </intent-filter>
 
         </activity>
-				<receiver android:name=".SettingsReceiver" >
+        <receiver android:name=".SettingsReceiver" >
             <intent-filter>
                 <action android:name="com.lr.keyguarddisabler.action.SET_PREFERENCE" />
             </intent-filter>

--- a/app/src/main/java/com/lr/keyguarddisabler/SettingsReceiver.java
+++ b/app/src/main/java/com/lr/keyguarddisabler/SettingsReceiver.java
@@ -31,13 +31,12 @@ public class SettingsReceiver extends BroadcastReceiver {
     Log.i(TAG, "SettingsReceiver:" + action);
 
     // Get the shared preferences to store the new lockscreentype value
-    SharedPreferences sp = context.getSharedPreferences("com.lr.keyguarddisabler_preferences", context.MODE_PRIVATE);
+    SharedPreferences sp = context.getSharedPreferences("com.lr.keyguarddisabler_preferences", context.MODE_WORLD_READABLE);
     SharedPreferences.Editor editor = sp.edit();
 
     // Get the value from the intent extra and store it in preference
     String lockScreenValue = intent.getStringExtra("lockscreentype");
     Log.i(TAG, "Lock screen value to set: " + lockScreenValue);
     Boolean done = editor.putString("lockscreentype", lockScreenValue).commit();
-    Log.i(TAG, "Lock screen value from preferences: " + sp.getString("lockscreentype", "not set"));
   }
 }


### PR DESCRIPTION
Just created a simple SettingsReceiver to receive intents broadcasted out from third party apps like Tasker. I just found out that a Tasker plugin is being developed but anyways since I created it I thought I would share.

**Usage:**
_adb shell am broadcast -a com.lr.keyguarddisabler.action.SET_PREFERENCE -e lockscreentype device/slide/none_

Tasker or any other 3rd party app can use Send Intents to send the desired lock screen type and this will take effect on the next screen lock.
