### PR TITLE
Add support for Lollipop

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,17 +1,17 @@
 apply plugin: 'com.android.application'
 android {
-    compileSdkVersion 19
-    buildToolsVersion '20.0.0'
+    compileSdkVersion 21
+    buildToolsVersion '21.1.2'
 
     defaultConfig {
         applicationId "com.lr.keyguarddisabler"
         minSdkVersion 10
-        targetSdkVersion 19
+        targetSdkVersion 21
     }
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            runProguard false // http://stackoverflow.com/a/27441250/801334
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
     <uses-sdk
         android:minSdkVersion="10"
-        android:targetSdkVersion="19" />
+        android:targetSdkVersion="21" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/lr/keyguarddisabler/Lockscreen.java
+++ b/app/src/main/java/com/lr/keyguarddisabler/Lockscreen.java
@@ -60,8 +60,19 @@ public class Lockscreen implements IXposedHookLoadPackage, IXposedHookZygoteInit
     @Override
     public void handleLoadPackage(final LoadPackageParam lpparam) throws Throwable {
 
+        // Android 5.0
+        if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) && (
+                lpparam.packageName.contains("android.keyguard") || lpparam.packageName.contains("com.android.systemui"))) {
+            if (LOG) XposedBridge.log("Keyguard Disabler: Loading Lollipop specific code");
+            hookAllNeededMethods(lpparam,
+                    "com.android.keyguard.KeyguardSecurityModel$SecurityMode",
+                    "com.android.keyguard.KeyguardSecurityModel",
+                    "com.android.systemui.keyguard.KeyguardViewMediator",
+                    "Android 5.0");
+        }
+
         // Android 4.4
-        if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) && lpparam.packageName.contains("android.keyguard")) {
+        else if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) && lpparam.packageName.contains("android.keyguard")) {
             if (LOG) XposedBridge.log("Keyguard Disabler: Loading Kitkat specific code");
             hookAllNeededMethods(lpparam,
                     "com.android.keyguard.KeyguardSecurityModel$SecurityMode",


### PR DESCRIPTION
Fixed issue #25 

KeyguardViewMediator moved on Lollipop from com.android.keyguard (package android.keyguard) to com.android.systemui.keyguard (package com.android.systemui).