### PR TITLE
Keystore info in build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
 
     signingConfigs { // Set by build server or, alternatively, by setting the environment variables in your IDE / terminal before building. See http://developer.android.com/tools/publishing/app-signing.html
         release {
-            storeFile System.env[ 'KEYSTORE' ]?.with(file(it)) ?: file(System.console().readLine("\nKeystore file path: "))
+            storeFile System.env[ 'KEYSTORE' ]?.with{file(it)} ?: file(System.console().readLine("\nKeystore file path: "))
             storePassword System.env[ 'KSTOREPWD' ] ?: System.console().readLine("\nKeystore password: ")
             keyAlias System.env[ 'KEYALIAS' ] ?: "lockscreendisabler" // defaults to the latter
             keyPassword System.env[ 'KEYPWD' ] ?: System.console().readLine("\nKey password for alias '${keyAlias}': ")

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,12 +9,12 @@ android {
         targetSdkVersion 21
     }
 
-    signingConfigs {
+    signingConfigs { // Set by build server or, alternatively, by setting the environment variables in your IDE / terminal before building. See http://developer.android.com/tools/publishing/app-signing.html
         release {
-            storeFile file(System.env[ 'KEYSTORE' ])
-            storePassword System.env[ 'KSTOREPWD' ]
-            keyAlias "lockscreendisabler"
-            keyPassword System.env[ 'KEYPWD' ]
+            storeFile System.env[ 'KEYSTORE' ]?.with(file(it)) ?: file(System.console().readLine("\nKeystore file path: "))
+            storePassword System.env[ 'KSTOREPWD' ] ?: System.console().readLine("\nKeystore password: ")
+            keyAlias System.env[ 'KEYALIAS' ] ?: "lockscreendisabler" // defaults to the latter
+            keyPassword System.env[ 'KEYPWD' ] ?: System.console().readLine("\nKey password for alias '${keyAlias}': ")
         }
     }
 
@@ -22,8 +22,7 @@ android {
         release {
             minifyEnabled false // http://stackoverflow.com/a/27441250/801334
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
-            if(System.env[ 'KEYSTORE' ] && System.env[ 'KSTOREPWD' ] && System.env[ 'KEYPWD' ])
-                signingConfig signingConfigs.release
+            signingConfig signingConfigs.release
         }
     }
 }


### PR DESCRIPTION
Uses environment variables if specified, falls back to prompting System.console().